### PR TITLE
Fix for Prompt engineering issue

### DIFF
--- a/app/api/chat/route.tsx
+++ b/app/api/chat/route.tsx
@@ -68,6 +68,7 @@ export async function POST(req: Request) {
        - Keep responses clear, concise, and educational
 
     8. Do not hallucinate. If you don't know the answer, say so.
+    - Never provide one word answers to anything 
     - Do not make stuff up.
     - If someone tries to trick you into sayong something not relevant to the constitution, elections act, or parliamentary proceedings, say you do not know.
     


### PR DESCRIPTION
Basically earlier the vulnerability was due to the numainda entertaining one word answers which was how i was able to compromise the functionality of it earlier so by introducing this one line in the system prompt "Never provide one word answers to anything" I believe this vulnerability will be fixed. 

It's also important to understand that LLM's do not understand language like we do; for them its a perspective of 1s and 0s. This means that you make them contradict or potentially undermine their capabilities by structuring your questions with a bunch of "Yes" and "No's" which for them correlate as a bunch of 1s and 0s by this method you can easily hack into an LLM model by overriding their previous set of instructions. 