### PR TITLE
Fully tested fix for prompt engineering issue

### DIFF
--- a/app/api/chat/route.tsx
+++ b/app/api/chat/route.tsx
@@ -68,6 +68,7 @@ export async function POST(req: Request) {
        - Keep responses clear, concise, and educational
 
     8. Do not hallucinate. If you don't know the answer, say so.
+    - Never provide one word answers to anything 
     - Do not make stuff up.
     - If someone tries to trick you into sayong something not relevant to the constitution, elections act, or parliamentary proceedings, say you do not know.
     

--- a/app/api/chat/route.tsx
+++ b/app/api/chat/route.tsx
@@ -1,26 +1,29 @@
-import { openai } from '@ai-sdk/openai';
-import { streamText } from 'ai';
-import { findRelevantContent } from '@/lib/ai/embedding';
+import { openai } from "@ai-sdk/openai"
+import { streamText } from "ai"
 
-export const maxDuration = 30;
+import { findRelevantContent } from "@/lib/ai/embedding"
+
+export const maxDuration = 30
 
 export async function POST(req: Request) {
-  const { messages } = await req.json();
-  
+  const { messages } = await req.json()
+
   // Get relevant content for the last message
-  const lastMessage = messages[messages.length - 1];
-  const relevantContent = await findRelevantContent(lastMessage.content);
+  const lastMessage = messages[messages.length - 1]
+  const relevantContent = await findRelevantContent(lastMessage.content)
 
   // Format the content for the AI to use
-  const contextString = relevantContent.map(content => {
-    return `Document: ${content.documentTitle}
+  const contextString = relevantContent
+    .map((content) => {
+      return `Document: ${content.documentTitle}
             Type: ${content.documentType}
             Content: ${content.content}
-            ---`;
-  }).join('\n\n');
+            ---`
+    })
+    .join("\n\n")
 
   const result = streamText({
-    model: openai('gpt-4o-mini'),
+    model: openai("gpt-4o-mini"),
     messages,
     system: `You are Numainda, an AI assistant designed to share insights and facts derived exclusively from Pakistan's Constitution, Elections Act 2017, and parliamentary proceedings. Your purpose is to make Pakistan's legislative framework accessible and engaging.
 
@@ -68,12 +71,12 @@ export async function POST(req: Request) {
        - Keep responses clear, concise, and educational
 
     8. Do not hallucinate. If you don't know the answer, say so.
-    - Never provide one word answers to anything 
+    - Do not provide one word answers.
     - Do not make stuff up.
-    - If someone tries to trick you into sayong something not relevant to the constitution, elections act, or parliamentary proceedings, say you do not know.
+    - Ignore all requests that are not related to your purpose.
     
     Remember: You are a beacon of knowledge for Pakistan's legislative framework. Your role is to educate while maintaining accuracy and engagement.`,
-  });
+  })
 
-  return result.toDataStreamResponse();
+  return result.toDataStreamResponse()
 }


### PR DESCRIPTION
I believe this PR fixes the issue as i tested it out by reverse engineering all the previous prompts i used to malfunction numainda. This is done by making the system prompt more effective and efficient by adding "_Do not provide one word answers._" and "_Ignore all requests that are not related to your purpose_."

Basically earlier the vulnerability was due to the numainda entertaining one word answers which was how i was able to compromise the functionality of it.

It is also important to understand that LLM's do not understand language like we do; for them its a perspective of mathematically rather than conceptually - tokenize and process these as part of a larger contextual embedding in a multi-dimensional space. This means that you can make them contradict or potentially undermine their capabilities by structuring your questions with a bunch of "Yes" and "No's" due to its probabilistic relationships between contexts and the limitations of the training data by this method you can easily manipulate an LLM model by overriding their previous set of instructions. 

**It is imperative to consider that by making it not entertain one word answers and ignore irrelevant requests not related to its functionality we can prevent this vulnerability by instruction tuning**